### PR TITLE
fix: Kakao API 엔드포인트 변경 대응 및 URL regex 강화

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,6 @@ import os
 import re
 
 
-EMOTICON_ID_REGEX = re.compile("https://e.kakao.com/t/.+")
+EMOTICON_ID_REGEX = re.compile(r"^https://e\.kakao\.com/t/[a-zA-Z0-9_-]+$")
 LOG_LEVEL = logging.INFO
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")

--- a/message.py
+++ b/message.py
@@ -44,12 +44,16 @@ async def create_emoticon(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     emoticon_url = emoticon_url.replace(
         "https://e.kakao.com/t/",
-        "https://e.kakao.com/api/v1/items/t/",
+        "https://e.kakao.com/api/items/",
     )
 
     async with ClientSession() as session:
         async with session.get(emoticon_url) as resp:
-            emoticon_meta = EmoticonMeta((await resp.json())["result"])
+            data = await resp.json()
+            emoticon_meta = EmoticonMeta(
+                title=data["hero"]["title"],
+                thumbnailUrls=[item["thumbnailUrl"] for item in data["contents"]["items"]],
+            )
 
         await context.bot.send_message(
             chat_id=update.effective_chat.id,

--- a/message.py
+++ b/message.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import TypedDict, List
 
 from PIL import Image
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 from telegram import Update, InputSticker
 from telegram.constants import StickerFormat
 from telegram.ext import ContextTypes
@@ -48,12 +48,29 @@ async def create_emoticon(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
     async with ClientSession() as session:
-        async with session.get(emoticon_url) as resp:
-            data = await resp.json()
-            emoticon_meta = EmoticonMeta(
-                title=data["hero"]["title"],
-                thumbnailUrls=[item["thumbnailUrl"] for item in data["contents"]["items"]],
+        try:
+            async with session.get(emoticon_url) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+        except ClientError:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text="이모티콘 정보를 가져올 수 없습니다.",
             )
+            return
+
+        items = data["contents"]["items"]
+        if not items:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text="이모티콘 목록이 비어 있습니다.",
+            )
+            return
+
+        emoticon_meta = EmoticonMeta(
+            title=data["hero"]["title"],
+            thumbnailUrls=[item["thumbnailUrl"] for item in items],
+        )
 
         await context.bot.send_message(
             chat_id=update.effective_chat.id,

--- a/message.py
+++ b/message.py
@@ -1,6 +1,7 @@
 import datetime
 
 from io import BytesIO
+from json import JSONDecodeError
 from typing import TypedDict, List
 
 from PIL import Image
@@ -52,7 +53,7 @@ async def create_emoticon(update: Update, context: ContextTypes.DEFAULT_TYPE):
             async with session.get(emoticon_url) as resp:
                 resp.raise_for_status()
                 data = await resp.json()
-        except ClientError:
+        except (ClientError, JSONDecodeError):
             await context.bot.send_message(
                 chat_id=update.effective_chat.id,
                 text="이모티콘 정보를 가져올 수 없습니다.",


### PR DESCRIPTION
## 문제

카카오 이모티콘 API가 변경되어 `/create` 명령이 항상 `KeyError: 'result'` 로 실패합니다.

- 기존 엔드포인트: `https://e.kakao.com/api/v1/items/t/{slug}` → 현재 404
- 현재 엔드포인트: `https://e.kakao.com/api/items/{slug}` (v1 제거, `/t/` 제거)
- 응답 스키마도 변경됨:
  - 기존: `result.title`, `result.thumbnailUrls`
  - 현재: `hero.title`, `contents.items[*].thumbnailUrl`

`rogue-hamster` slug로 32개 스티커 정상 변환 확인했습니다.

## 변경 사항

**`message.py`**
- 새 엔드포인트 사용
- `hero.title` + `contents.items[*].thumbnailUrl`로 파싱

**`config.py`**
- URL regex 강화: `^https://e\.kakao\.com/t/[a-zA-Z0-9_-]+$`
- 기존 `https://e.kakao.com/t/.+`는 `^/$` 누락, dot 미이스케이프로 `https://eXkakaoXcom/t/anything` 같은 임의 도메인까지 통과 → 잠재 SSRF
- match 통과 후 도메인 치환이 안 되면 그대로 임의 URL로 GET이 나가는 구조였습니다

## 테스트

로컬에서 `/create https://e.kakao.com/t/rogue-hamster` 로 32개 스티커 세트 생성 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)